### PR TITLE
Don't bail on unknown target triplets

### DIFF
--- a/guix/rustup/build/manifest.scm
+++ b/guix/rustup/build/manifest.scm
@@ -570,9 +570,7 @@
         (define uri-triplet-index (and uri (strip-uri-target-triplet-index uri)))
         (define triplet-index (%rustc-target-triplets->position (car target)))
 
-        (unless triplet-index
-          (error "Invalid triplet :" (car target)))
-        (if hash
+        (if (and hash triplet-index)
             (validate-url-pattern
              component-name-index
              triplet-index


### PR DESCRIPTION
Tiny change to avoid breakage every time a new triplet is added upstream.

Feedback appriciated